### PR TITLE
Parsing prereqs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 db.pl
 test.pl
 *~
+*#

--- a/get_all_links.pl
+++ b/get_all_links.pl
@@ -1,4 +1,4 @@
-:- module(get_all_links, [get_prereq_links/3]).
+:- module(get_all_links, [get_all_prereq_links/3, get_a_prereq_link/3]).
 :- license(lgpl).
 
 link_part_1("https://act.ucsd.edu/scheduleOfClasses/scheduleOfClassesPreReq.htm?termCode=").
@@ -14,13 +14,25 @@ link_part_2("&courseId=").
 % get_prereq_links/3 predicate will build and return a list of all
 % links that can be used to get the prerequisites from the 
 % UCSD schedule page.
-get_prereq_links(Qrt, CourseIds, AllLinks) :- 
+get_all_prereq_links(Qrt, CourseIds, AllLinks) :- 
+	link_concat(Qrt, Link),
+	get_prereq_links_1(Link, CourseIds, AllLinks).
+
+%% A predicate that allows you to get the prerequisites
+% link for a specific course.
+%
+% Qrt - expected to be a String indicating specific quarter.
+% CourseID - expected to be a string for a specific course.
+% Link - resultant link that gives prerequisites for this course.
+get_a_prereq_link(Qrt, CourseID, Link) :-
+	link_concat(Qrt, L),
+	get_prereq_links_1(L, [CourseID], Link).
+
+link_concat(Qrt, Link) :-
 	link_part_1(PartOne),
-	link_part_2(PartTwo),
-	string_concat(PartOne, Qrt, L),
-	string_concat(L, PartTwo, Link),
-	get_prereq_links_1(Link, CourseIds, AllLinks),
-	true.
+        link_part_2(PartTwo),
+        string_concat(PartOne, Qrt, L),
+        string_concat(L, PartTwo, Link).
 
 get_prereq_links_1(_, [], []).
 

--- a/parsePrereq.pl
+++ b/parsePrereq.pl
@@ -1,0 +1,41 @@
+:- module(parse_prereqs, [parse_a_class_prereqs/2, parse_multi_class_prereqs/2]).
+:- license(lgpl).
+
+:- use_module(get_all_links, [get_all_prereq_links/3, get_a_prereq_link/3]).
+
+:- use_module(library(http/http_ssl_plugin)).
+:- use_module(library(http/http_open)).
+:- use_module(library(xpath)).
+
+
+%%	Obtains all prerequisites for a specific course.
+% CourseID is expected to be a courseID.
+% Prereqs is [ ['CSE 11', 'or', 'CSE 8B'], ['CSE XXX']].
+parse_a_class_prereqs(CourseID, Prereqs) :-
+	once(get_a_prereq_link("WI14", CourseID, [URL|_])),
+	scrape(URL, Prereqs).
+
+%%	Obtains all prerequisites for a list of courses.
+% CourseIDs is a list of courses that contains the names of the courses
+% as atoms.
+% Prereqs is a list of lists of courseID and list of prerequisites.
+% i.e. [ [ 'CSE 12', [ ['CSE 11', 'or', 'CSE 8B'], [ 'CSE XXX']]], ..].
+
+parse_multi_class_prereqs(CourseIDs, Prereqs) :-
+	parse_list(CourseIDs, Prereqs).
+
+scrape(URL, Data) :-
+    setup_call_cleanup(http_open(URL, In, []),
+        scrape_stream(In, Data),
+        close(In)).
+
+scrape_stream(In, Data) :-
+    load_html(In, DOM, [syntax_errors(quiet)]),
+    prereqs(DOM, Data).
+
+parse_list([],[]).
+parse_list([Course | T], [[Course | ListOfPrereqs]|ParsePrereqs]) :-
+	parse_a_class_prereqs(Course, ListOfPrereqs),
+	parse_list(T, ParsePrereqs).
+
+prereqs(DOM, Prereqs) :- true.

--- a/parsePrereq.pl
+++ b/parsePrereq.pl
@@ -11,8 +11,8 @@
 %%	Obtains all prerequisites for a specific course.
 % CourseID is expected to be a courseID.
 % Prereqs is [ ['CSE 11', 'or', 'CSE 8B'], ['CSE XXX']].
-parse_a_class_prereqs(CourseID, Prereqs) :-
-    once(get_a_prereq_link("WI14", CourseID, [URL|_])),
+parse_a_class_prereqs(CourseID, [CourseID|Prereqs]) :-
+    once(get_a_prereq_link("WI15", CourseID, [URL|_])),
     scrape(URL, Prereqs).
 
 %%	Obtains all prerequisites for a list of courses.
@@ -40,7 +40,7 @@ scrape_stream(In, Data) :-
     true.
 
 parse_list([],[]).
-parse_list([Course | T], [[Course | ListOfPrereqs]|ParsePrereqs]) :-
+parse_list([Course | T], [ListOfPrereqs|ParsePrereqs]) :-
     parse_a_class_prereqs(Course, ListOfPrereqs),
     parse_list(T, ParsePrereqs).
 
@@ -53,17 +53,10 @@ prereqs(DOM, Prereqs) :-
     true.
 
 prereqs_tds([], []).
-prereqs_tds([TR|Tail], Result) :-
+prereqs_tds([TR|Tail], [RelSpans|Spans]) :-
     findall(T, xpath(TR, //td, T), TD),
-    prereqs_tds(Tail, Spans),
     [_|RelevantTD] = TD,
-    get_span(RelevantTD, RelSpans),
-    append(RelSpans, Spans, Result),
-    true.
-
-get_span(ResultTDs, Spans) :-
-    xpath(ResultTDs, //span(normalize_space), Spans),
-    true.
-
+    findall(Span, xpath(RelevantTD, //span(normalize_space), Span), RelSpans),
+    prereqs_tds(Tail, Spans).
 
 

--- a/parsePrereq.pl
+++ b/parsePrereq.pl
@@ -12,8 +12,8 @@
 % CourseID is expected to be a courseID.
 % Prereqs is [ ['CSE 11', 'or', 'CSE 8B'], ['CSE XXX']].
 parse_a_class_prereqs(CourseID, Prereqs) :-
-	once(get_a_prereq_link("WI14", CourseID, [URL|_])),
-	scrape(URL, Prereqs).
+    once(get_a_prereq_link("WI14", CourseID, [URL|_])),
+    scrape(URL, Prereqs).
 
 %%	Obtains all prerequisites for a list of courses.
 % CourseIDs is a list of courses that contains the names of the courses
@@ -21,20 +21,42 @@ parse_a_class_prereqs(CourseID, Prereqs) :-
 % Prereqs is a list of lists of courseID and list of prerequisites.
 % i.e. [ [ 'CSE 12', [ ['CSE 11', 'or', 'CSE 8B'], [ 'CSE XXX']]], ..].
 parse_multi_class_prereqs(CourseIDs, Prereqs) :-
-	parse_list(CourseIDs, Prereqs).
+    parse_list(CourseIDs, Prereqs).
 
 scrape(URL, Data) :-
-    setup_call_cleanup(http_open(URL, In, []),
-        scrape_stream(In, Data),
-        close(In)).
+    setup_call_cleanup(
+	http_open(URL, Stream, [cert_verify_hook(cert_verify)]),
+        scrape_stream(Stream, Data),
+        close(Stream)).
+
+cert_verify(SSL, ProblemCert, AllCerts, FirstCert, Error) :-
+    debug(shopping(cert),
+      'Accepting certificate SSL:~w~n ProblemCert:~w~n AllCerts:~w~n FirstCert:~w~n Error:~w~n',
+      [SSL, ProblemCert, AllCerts, FirstCert, Error]).
 
 scrape_stream(In, Data) :-
     load_html(In, DOM, [syntax_errors(quiet)]),
-    prereqs(DOM, Data).
+    prereqs(DOM, Data),
+    true.
 
 parse_list([],[]).
 parse_list([Course | T], [[Course | ListOfPrereqs]|ParsePrereqs]) :-
-	parse_a_class_prereqs(Course, ListOfPrereqs),
-	parse_list(T, ParsePrereqs).
+    parse_a_class_prereqs(Course, ListOfPrereqs),
+    parse_list(T, ParsePrereqs).
 
-prereqs(DOM, Prereqs) :- true.
+prereqs(DOM, Prereqs) :-
+    findall(Prereq, prereqs_1(DOM, Prereq), [_|T]),
+    prereqs_2(T, Prereqs),
+    true.
+
+prereqs_1(DOM, Prereq) :-
+    xpath(DOM, //table, Prereq),
+    true.
+
+prereqs_2(TBL, Prereq) :-
+    xpath(TBL, //tr, TRs),
+    prereqs_3(TRs, Prereq),
+    true.
+
+prereqs_3(T, T).
+

--- a/parsePrereq.pl
+++ b/parsePrereq.pl
@@ -1,0 +1,26 @@
+:- module(parse_prereqs, [parse_prereqs/2]).
+:- license(lgpl).
+
+:- use_module(get_all_links, [get_all_prereq_links/3, get_a_prereq_link/3]).
+
+:- use_module(library(http/http_open)).
+:- use_module(library(xpath)).
+
+%%	Obtains all prerequisites for a specific course.
+% CourseID is expected to be a courseID.
+% Prereqs is [ ['CSE 11', 'or', 'CSE 8B'], ['CSE XXX']].
+parse_prereqs(CourseID, Prereqs) :- true.
+
+
+%%	Obtains all prerequisites for a list of courses.
+% CourseIDs is a list of courses that contains the names of the courses
+% as atoms.
+% Prereqs is a list of lists of courseID and list of prerequisites.
+% i.e. [ [ 'CSE 12', [ ['CSE 11', 'or', 'CSE 8B'], [ 'CSE XXX']]], ..].
+parse_prereqs(CourseIDs, Prereqs) :-
+	parse_list(CourseIDs, Prereqs),
+	true.
+
+parse_list([Course | T], Prereqs) :-
+	parse_prereqs(Course, ListOfPrereqs),
+	true.

--- a/parsePrereq.pl
+++ b/parsePrereq.pl
@@ -45,18 +45,25 @@ parse_list([Course | T], [[Course | ListOfPrereqs]|ParsePrereqs]) :-
     parse_list(T, ParsePrereqs).
 
 prereqs(DOM, Prereqs) :-
-    findall(Prereq, prereqs_1(DOM, Prereq), [_|T]),
-    prereqs_2(T, Prereqs),
+    % Get all the tables.
+    findall(Prereq, xpath(DOM, //table, Prereq), [_|Ttable]),
+    % Ignore the first table, and extract all <tr>.
+    findall(Table, xpath(Ttable, //tr, Table), [_|Trows]),
+    findall(Rows, prereqs_tds(Trows, Rows), Prereqs),
     true.
 
-prereqs_1(DOM, Prereq) :-
-    xpath(DOM, //table, Prereq),
+prereqs_tds([], []).
+prereqs_tds([TR|Tail], Result) :-
+    findall(T, xpath(TR, //td, T), TD),
+    prereqs_tds(Tail, Spans),
+    [_|RelevantTD] = TD,
+    get_span(RelevantTD, RelSpans),
+    append(RelSpans, Spans, Result),
     true.
 
-prereqs_2(TBL, Prereq) :-
-    xpath(TBL, //tr, TRs),
-    prereqs_3(TRs, Prereq),
+get_span(ResultTDs, Spans) :-
+    xpath(ResultTDs, //span(normalize_space), Spans),
     true.
 
-prereqs_3(T, T).
+
 

--- a/parsePrereq.pl
+++ b/parsePrereq.pl
@@ -1,4 +1,4 @@
-:- module(parse_prereqs, [parse_a_class_prereqs/2, parse_multi_class_prereqs/2]).
+:- module(parse_prereqs, [parse_a_class_prereqs/3, parse_multi_class_prereqs/3]).
 :- license(lgpl).
 
 :- use_module(get_all_links, [get_all_prereq_links/3, get_a_prereq_link/3]).
@@ -10,18 +10,25 @@
 
 %%	Obtains all prerequisites for a specific course.
 % CourseID is expected to be a courseID.
+%
+% Sample: 
+%
 % Prereqs is [ ['CSE 11', 'or', 'CSE 8B'], ['CSE XXX']].
-parse_a_class_prereqs(CourseID, [CourseID|Prereqs]) :-
-    once(get_a_prereq_link("WI15", CourseID, [URL|_])),
+parse_a_class_prereqs(CourseID, Qrt, [CourseID|Prereqs]) :-
+    once(get_a_prereq_link(Qrt, CourseID, [URL|_])),
     scrape(URL, Prereqs).
 
 %%	Obtains all prerequisites for a list of courses.
 % CourseIDs is a list of courses that contains the names of the courses
 % as atoms.
+%
+% Sample usage:
+% 	course_ids(CourseIDs), parse_multi_class_prereqs(CourseIDs, Prereqs).
+%
 % Prereqs is a list of lists of courseID and list of prerequisites.
 % i.e. [ [ 'CSE 12', [ ['CSE 11', 'or', 'CSE 8B'], [ 'CSE XXX']]], ..].
-parse_multi_class_prereqs(CourseIDs, Prereqs) :-
-    parse_list(CourseIDs, Prereqs).
+parse_multi_class_prereqs(CourseIDs, Qrt, Prereqs) :-
+    parse_list(CourseIDs, Qrt, Prereqs).
 
 scrape(URL, Data) :-
     setup_call_cleanup(
@@ -39,10 +46,10 @@ scrape_stream(In, Data) :-
     prereqs(DOM, Data),
     true.
 
-parse_list([],[]).
-parse_list([Course | T], [ListOfPrereqs|ParsePrereqs]) :-
-    parse_a_class_prereqs(Course, ListOfPrereqs),
-    parse_list(T, ParsePrereqs).
+parse_list([],_,[]).
+parse_list([Course | T], Qrt, [ListOfPrereqs|ParsePrereqs]) :-
+    parse_a_class_prereqs(Course, Qrt, ListOfPrereqs),
+    parse_list(T, Qrt, ParsePrereqs).
 
 prereqs(DOM, Prereqs) :-
     % Get all the tables.


### PR DESCRIPTION
File parsePrereqs.pl contains predicates that parse the HTML URL for a particular class ID and get back the requirements for the course.

For usage of the predicates, please explore the file.
